### PR TITLE
Update Readme and Default Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@ This module creates a bucket to hold the remote state files of terraform, a dyna
 
 ## How to Use
 You will need a `main.tf` to call this module with the correct parameters.
-Example:
+
+### Simple Example
+To use this module out-of-the-box, without changing the default behaviour
+
+```HCL
+provider "aws" {}
+
+module "remote_state" {
+  source = "ansraliant/s3-state/aws"
+
+  bucket_name    = "mybucket"
+  dynamodb_table = "mydynamodb"
+  states         = { infra = "../backend.tf.json" }
+}
+```
+
+### Full Config Example
+How to use with full config
 
 ```HCL
 locals {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ You will need a `main.tf` to call this module with the correct parameters.
 To use this module out-of-the-box, without changing the default behaviour
 
 ```HCL
-provider "aws" {}
+provider "aws" {
+  region = "ap-northeast-1"
+}
 
 module "remote_state" {
   source = "ansraliant/s3-state/aws"
@@ -20,13 +22,13 @@ module "remote_state" {
 }
 ```
 
-### Full Config Example
-How to use with full config
+### Advanced Config Example
+How to use with advanced config
 
 ```HCL
 locals {
   prefix  = "myproject"
-  profile = "default"
+  profile = "my-aws-profile"
   region  = "ap-northeast-1"
 
   states = {

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,7 @@
 variable "profile" {
   type = string
+
+  default = "default"
 }
 
 variable "bucket_name" {


### PR DESCRIPTION
Adds a simple example on how to use the module without any extra config other than the required ones.

And changes the default profile of aws to `default`