### PR TITLE
Add support for S3 Lifecycle configuration

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -48,3 +48,27 @@ resource "aws_s3_bucket_versioning" "this" {
     status = "Enabled"
   }
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "state_cleanup" {
+  count = var.lifecycle_config != null ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = var.lifecycle_config.name
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days           = var.lifecycle_config.noncurrent_days
+      newer_noncurrent_versions = var.lifecycle_config.newer_noncurrent_versions
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.lifecycle_config.abort_multipart_days
+    }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,16 @@ variable "dynamodb_table" {
 
   description = "Use DynamoDB table for state locking. This is useful only for compatibility with Terraform/OpenTofu prior to 1.10.0."
 }
+
+variable "lifecycle_config" {
+  type = object({
+    name                      = optional(string, "cleanup-old-versions")
+    noncurrent_days           = optional(number, 30)
+    newer_noncurrent_versions = optional(number, 10)
+    abort_multipart_days      = optional(number, 7)
+  })
+
+  default     = null
+
+  description = "Configuration for the S3 bucket lifecycle configuration. This is used to automatically clean up old versions of the state files and abort incomplete multipart uploads. It is recommended to enable this to avoid unnecessary storage costs."
+}


### PR DESCRIPTION
Adds the possibility to add lifecycle policies to the S3 buckets, so that you don't end up paying for each version of the remote state.

Reference documentation for [aws_s3_bucket_lifecycle_configuration](https://registry.terraform.io/providers/-/aws/latest/docs/resources/s3_bucket_lifecycle_configuration)